### PR TITLE
Allow gatling to start at head block time of 2 seconds or less

### DIFF
--- a/dev/testnet/testnetinit.sh
+++ b/dev/testnet/testnetinit.sh
@@ -110,7 +110,7 @@ sleep 120
 
 # wait for seed to be synced before proceeding
 BLOCK_AGE=500
-while [[ BLOCK_AGE -ge 1 ]]
+while [[ BLOCK_AGE -ge 3 ]]
 do
 BLOCKCHAIN_TIME=$(
     curl --silent --max-time 3 \


### PR DESCRIPTION
Instead of waiting for 0 seconds behind to start gatling, allow 2 seconds or less. In testing, it looks like 0, 1, and 2 are all normally received responses once it is already synced.