### PR TITLE
add rc_api plugin

### DIFF
--- a/dev/testnet/testnet.config.ini
+++ b/dev/testnet/testnet.config.ini
@@ -11,7 +11,7 @@ log-logger = {"name":"p2p","level":"info","appender":"stderr"}
 # Plugin(s) to enable, may be specified multiple times
 plugin = webserver p2p json_rpc witness account_by_key tags follow market_history account_history
 
-plugin = database_api account_by_key_api network_broadcast_api tags_api follow_api market_history_api witness_api condenser_api account_history_api block_api
+plugin = database_api account_by_key_api network_broadcast_api tags_api follow_api market_history_api witness_api condenser_api account_history_api block_api rc_api
 
 # Size of the shared memory file. Default: 54G
 shared-file-size = 30G


### PR DESCRIPTION
Enables `rc_api` in `testnet.config.ini`. Unclear if needed in `fastgen.config.ini` as well.