### PR TITLE
Nginx conf is pulled in externally

### DIFF
--- a/dev/testnet/testnetinit.sh
+++ b/dev/testnet/testnetinit.sh
@@ -29,7 +29,9 @@ cd $HOME
 
 mv /etc/nginx/nginx.conf /etc/nginx/nginx.original.conf
 cp /etc/nginx/steemd.nginx.conf /etc/nginx/nginx.conf
-cp ./testnet-web-console.conf /etc/nginx/sites-enabled/testnet-web-console.conf
+# testnet nginx conf is pulled in directly from steem repo
+# leaving the line below for when we change that flow
+# cp ./testnet-web-console.conf /etc/nginx/sites-enabled/testnet-web-console.conf
 
 # for appbase tags plugin loading
 ARGS+=" --tags-skip-startup-update"


### PR DESCRIPTION
For now, let the testnet nginx conf be placed by the steem repo.