### PR TITLE
Use main nginx conf for testnet location directives

### DIFF
--- a/dev/testnet/testnet-web-console.conf
+++ b/dev/testnet/testnet-web-console.conf
@@ -1,7 +1,33 @@
-location /account_create {
-    proxy_pass http://127.0.0.1:5000/account_create;
-}
+  server {
+    listen 0.0.0.0:8090;
 
-location /static {
-    proxy_pass http://127.0.0.1:5000/static;
+    location /health {
+      fastcgi_pass unix:/var/run/fcgiwrap.socket;
+      fastcgi_param SCRIPT_FILENAME /usr/local/bin/healthcheck.sh;
+    }
+
+    location /account_create {
+        proxy_pass http://127.0.0.1:5000/account_create;
+    }
+
+    location /static {
+        proxy_pass http://127.0.0.1:5000/static;
+    }
+
+    location / {
+      access_log off;
+      proxy_pass http://ws;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_http_version 1.1;
+      proxy_buffering off;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+      add_header Access-Control-Allow-Origin "*";
+      add_header Access-Control-Allow-Methods "GET, POST, OPTIONS";
+      add_header Access-Control-Allow-Headers "DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range";
+      add_header Strict-Transport-Security "max-age=31557600; includeSubDomains; preload" always;
+    }
 }
+  upstream ws {


### PR DESCRIPTION
The file in this repo stays the same name, but is now the main 'healthcheck.conf' nginx config file that will be overwritten by the steem repo at testnet launch